### PR TITLE
Add rigged monster model with correct collision boxes

### DIFF
--- a/Content/Enemy1/AnimationsAI1/MonsterBlendSpace1D.uasset
+++ b/Content/Enemy1/AnimationsAI1/MonsterBlendSpace1D.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d247109ee8e913dbbde1fed57d7f0fe3b72f75c5b8336cde822585735b8aa3a8
+size 6055

--- a/Content/Enemy1/Enemy1/DEMON_NORM.uasset
+++ b/Content/Enemy1/Enemy1/DEMON_NORM.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b2ec461fcb72fbd971d20b2c36ec1001b114bb66d58ba634f21928b674ac6b8
+size 15538645

--- a/Content/Enemy1/Enemy1/DEMON_OCC.uasset
+++ b/Content/Enemy1/Enemy1/DEMON_OCC.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5171e643dcbeec7f67c62a3120d461b0c5ef8c945cb2a9dcb4ab47d7b7e7c9a2
+size 10268840

--- a/Content/Enemy1/Enemy1/DEMON_SHINE.uasset
+++ b/Content/Enemy1/Enemy1/DEMON_SHINE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d322ad5a88130606796d2e9fcd6c3f9e5c294fc53a303ae728c90a145747dba8
+size 10037508

--- a/Content/Enemy1/Enemy1/DEMON_SPEC.uasset
+++ b/Content/Enemy1/Enemy1/DEMON_SPEC.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:901843960fd4e7e46b4f00a2a5f54d6676111e90cba6cb8938b4aaa0e868c393
+size 9866945

--- a/Content/Enemy1/Enemy1/DEMON_TEXTURE.uasset
+++ b/Content/Enemy1/Enemy1/DEMON_TEXTURE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcf7718d386bc0357503461c33b520ecfd7d731b14b26925896d235e12ddecf5
+size 20667927

--- a/Content/Enemy1/Enemy1/DemonIDLE.uasset
+++ b/Content/Enemy1/Enemy1/DemonIDLE.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61570d13c7ad58020f2485fc6d163e88cdac9a06526493f520d2b69794871b4b
+size 4349093

--- a/Content/Enemy1/Enemy1/DemonIDLE_CtrlRig.uasset
+++ b/Content/Enemy1/Enemy1/DemonIDLE_CtrlRig.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fa9a75643392e41d345aff6eea1a9ce53537df703889efc99737b3cb90acb37
+size 114560

--- a/Content/Enemy1/Enemy1/DemonIDLE_PhysicsAsset.uasset
+++ b/Content/Enemy1/Enemy1/DemonIDLE_PhysicsAsset.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e7ab59c971d779383d6d83755e9b9ec9cb96ace1330e722c43adabe19d6a4ba
+size 7222

--- a/Content/Enemy1/Enemy1/DemonIDLE_PhysicsAsset.uasset
+++ b/Content/Enemy1/Enemy1/DemonIDLE_PhysicsAsset.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7e7ab59c971d779383d6d83755e9b9ec9cb96ace1330e722c43adabe19d6a4ba
-size 7222
+oid sha256:2ce84d8296413bd13b3328643e07445fb727f1422e3790b469428acd0db7b0c5
+size 13034

--- a/Content/Enemy1/Enemy1/DemonIDLE_Skeleton.uasset
+++ b/Content/Enemy1/Enemy1/DemonIDLE_Skeleton.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0a04917b2467e79c855d43a9928670e270060e80e9224cf1a3fd98046c35649
+size 32024

--- a/Content/Enemy1/Enemy1/lambert1.uasset
+++ b/Content/Enemy1/Enemy1/lambert1.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99cb8854c1caf58ef2750399640c67b93c691507ba2f2dc118e7e357eadc4e52
+size 8655


### PR DESCRIPTION
添加了第一款怪物的模型以及定义了骨架和正确的碰撞体。

![monster1](https://github.com/A72craft/CS415_Project_Group2/assets/109250996/241503df-5750-44a4-9b65-5b777b88332d)

